### PR TITLE
Avoid mixed-content warning by preferring HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>HTML5 Storage Benchmark</title>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script>
 
     <script type="text/javascript" src="https://www.google.com/jsapi"></script>
 


### PR DESCRIPTION
If you try to load https://reyesr.github.io/html5-storage-benchmark/ it will fail because the jQuery link is http. Switching it to https makes both https://reyesr.github.io/html5-storage-benchmark/ and http://reyesr.github.io/html5-storage-benchmark/ work.